### PR TITLE
Completes code generation for http operations

### DIFF
--- a/api/src/main/java/cloud/benchflow/driversmaker/requests/Experiment.java
+++ b/api/src/main/java/cloud/benchflow/driversmaker/requests/Experiment.java
@@ -14,8 +14,8 @@ public class Experiment {
 
     private String userId;
 
-    @JsonProperty("benchmarkName")
-    private String benchmarkName;
+    @JsonProperty("experimentName")
+    private String experimentName;
 
     @JsonProperty("experimentNumber")
     private long experimentNumber;
@@ -23,12 +23,12 @@ public class Experiment {
     @JsonProperty("trials")
     private int totalTrials;
 
-    public String getBenchmarkName() {
-        return benchmarkName;
+    public String getExperimentName() {
+        return experimentName;
     }
 
-    public void setBenchmarkName(String benchmarkName) {
-        this.benchmarkName = benchmarkName;
+    public void setExperimentName(String experimentName) {
+        this.experimentName = experimentName;
     }
 
     public long getExperimentNumber() {
@@ -49,7 +49,7 @@ public class Experiment {
 
     public String getExperimentId() { return getBenchmarkId() + "." + experimentNumber; }
 
-    public String getBenchmarkId() { return userId + "." + benchmarkName; }
+    public String getBenchmarkId() { return userId + "." + experimentName; }
 
     public Trial getTrial(int trialNumber) {
         if(trialNumber > totalTrials)

--- a/application/src/main/java/cloud/benchflow/driversmaker/resources/FabanBenchmarkGeneratorResource.java
+++ b/application/src/main/java/cloud/benchflow/driversmaker/resources/FabanBenchmarkGeneratorResource.java
@@ -82,7 +82,7 @@ public class FabanBenchmarkGeneratorResource {
     }
 
     private void cleanUp(Experiment experiment) {
-        String minioBenchmarkId = experiment.getUserId() + "/" + experiment.getBenchmarkName();
+        String minioBenchmarkId = experiment.getUserId() + "/" + experiment.getExperimentName();
         long experimentNumber = experiment.getExperimentNumber();
         Iterator<Trial> trials = experiment.getAllTrials();
         minio.removeTestConfigurationForExperiment(minioBenchmarkId, experimentNumber);
@@ -100,26 +100,19 @@ public class FabanBenchmarkGeneratorResource {
         //temporary user id
         experiment.setUserId("BenchFlow");
         String benchmarkId = experiment.getBenchmarkId();
-        String minioBenchmarkId = experiment.getUserId() + "/" + experiment.getBenchmarkName();
+        String minioBenchmarkId = experiment.getUserId() + "/" + experiment.getExperimentName();
 
         String experimentId = experiment.getExperimentId();
         String minioExperimentId = experimentId.replace(".", "/");
         long experimentNumber = experiment.getExperimentNumber();
-
-        //temporary: get zip of sources and copy in temporary folder
-//        InputStream sources = minio.getBenchmarkSources(minioBenchmarkId);
-//        logger.debug("Retrieved driver sources from minio");
 
         try(ManagedDirectory managedDriverPath = new ManagedDirectory(
                 "./tmp/" + benchmarkId + "/" + experiment.getExperimentId())
             ) {
 
             Path driverPath = managedDriverPath.getPath();
-//            FileUtils.forceMkdir(driverPath.toFile());
-//            ZipUtil.unwrap(sources, driverPath.toFile());
 
             //copy skeleton in temporary folder
-//            Path generationResources = Paths.get("./application/src/test/resources/app/drivers");
             Path generationResources = Paths.get(benv.getGenerationResourcesPath());
             Path skeletonPath = generationResources.resolve("templates/skeleton/benchmark");
             FileUtils.copyDirectory(skeletonPath.toFile(), driverPath.toFile());

--- a/application/src/main/scala/cloud/benchflow/experiment/GenerationDefaults.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/GenerationDefaults.scala
@@ -53,4 +53,6 @@ object GenerationDefaults {
 
   val interval = 1
 
+  val max90th = Double.MaxValue
+
 }

--- a/application/src/main/scala/cloud/benchflow/experiment/sources/generators/BenchmarkSourcesGenerator.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/sources/generators/BenchmarkSourcesGenerator.scala
@@ -32,7 +32,7 @@ import scala.reflect.ClassTag
   * @param driver driver configuration
   * @tparam A implementation of [[DriverOperationsProcessor]]
   */
-abstract class DriverGenerator[A <: DriverOperationsProcessor: ClassTag](val generatedDriverClassOutputDir: Path,
+abstract class DriverGenerator[A <: DriverOperationsProcessor[_]: ClassTag](val generatedDriverClassOutputDir: Path,
                                                                          val generationResources: Path,
                                                                          val expConfig: BenchFlowExperiment,
                                                                          val driver: Driver[_ <: Operation],

--- a/application/src/main/scala/cloud/benchflow/experiment/sources/generators/http/HttpDriverGenerator.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/sources/generators/http/HttpDriverGenerator.scala
@@ -7,7 +7,7 @@ import cloud.benchflow.experiment.sources.generators.DriverGenerator
 import cloud.benchflow.experiment.sources.processors.drivers.annotations.BenchmarkDefinitionAnnotation
 import cloud.benchflow.experiment.sources.processors.drivers.operations.http.HttpDriverOperationsProcessor
 import cloud.benchflow.test.config.experiment.BenchFlowExperiment
-import cloud.benchflow.test.config.sut.http.HttpDriver
+import cloud.benchflow.test.config.sut.http.{HttpOperation, HttpDriver}
 
 /**
   * @author Simone D'Avico (simonedavico@gmail.com)
@@ -18,8 +18,8 @@ class HttpDriverGenerator(generatedDriverClassOutputDir: Path,
                           generationResources: Path,
                           expConfig: BenchFlowExperiment,
                           experimentId: String,
-                          driver: HttpDriver)(env: DriversMakerEnv)
-  extends DriverGenerator[HttpDriverOperationsProcessor](generatedDriverClassOutputDir,
+                          driver: HttpDriver)(implicit env: DriversMakerEnv)
+  extends DriverGenerator[HttpDriverOperationsProcessor[HttpOperation]](generatedDriverClassOutputDir,
     generationResources,
     expConfig,
     driver,

--- a/application/src/main/scala/cloud/benchflow/experiment/sources/generators/wfms/WfMSDriverGenerator.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/sources/generators/wfms/WfMSDriverGenerator.scala
@@ -4,10 +4,11 @@ import java.nio.file.Path
 
 import cloud.benchflow.driversmaker.utils.env.DriversMakerEnv
 import cloud.benchflow.experiment.sources.generators.DriverGenerator
-import cloud.benchflow.experiment.sources.processors.{WfMSPluginLoaderProcessor, BenchmarkSourcesProcessor, WfMSDriverOperationsProcessor}
+import cloud.benchflow.experiment.sources.processors.drivers.operations.wfms.WfMSDriverOperationsProcessor
+import cloud.benchflow.experiment.sources.processors.{WfMSPluginLoaderProcessor, BenchmarkSourcesProcessor}
 import cloud.benchflow.experiment.sources.utils.ResolvePlugin
 import cloud.benchflow.test.config.experiment.BenchFlowExperiment
-import cloud.benchflow.test.config.sut.wfms.WfMSDriver
+import cloud.benchflow.test.config.sut.wfms.{WfMSOperation, WfMSDriver}
 
 import scala.reflect.ClassTag
 
@@ -16,7 +17,7 @@ import scala.reflect.ClassTag
   *
   * Created on 25/07/16.
   */
-abstract class WfMSDriverGenerator[A <: WfMSDriverOperationsProcessor: ClassTag](generatedDriverClassOutputDir: Path,
+abstract class WfMSDriverGenerator[A <: WfMSDriverOperationsProcessor[_ <: WfMSOperation]: ClassTag](generatedDriverClassOutputDir: Path,
                                                                                  generationResources: Path,
                                                                                  expConfig: BenchFlowExperiment,
                                                                                  experimentId: String,

--- a/application/src/main/scala/cloud/benchflow/experiment/sources/generators/wfms/WfMSStartDriverGenerator.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/sources/generators/wfms/WfMSStartDriverGenerator.scala
@@ -7,7 +7,7 @@ import cloud.benchflow.experiment.sources.processors.BenchmarkSourcesProcessor
 import cloud.benchflow.experiment.sources.processors.drivers.annotations.BenchmarkDefinitionAnnotation
 import cloud.benchflow.experiment.sources.processors.drivers.operations.wfms.WfMSStartDriverOperationsProcessor
 import cloud.benchflow.test.config.experiment.BenchFlowExperiment
-import cloud.benchflow.test.config.sut.wfms.WfMSStartDriver
+import cloud.benchflow.test.config.sut.wfms.{WfMSOperation, WfMSStartDriver}
 
 /**
   * @author Simone D'Avico (simonedavico@gmail.com)
@@ -26,7 +26,7 @@ class WfMSStartDriverGenerator(generatedDriverClassOutputDir: Path,
                                experimentId: String,
                                driver: WfMSStartDriver)
                               (implicit env: DriversMakerEnv)
-  extends WfMSDriverGenerator[WfMSStartDriverOperationsProcessor](generatedDriverClassOutputDir,
+  extends WfMSDriverGenerator[WfMSStartDriverOperationsProcessor[WfMSOperation]](generatedDriverClassOutputDir,
     generationResources,
     expConfig,
     experimentId,

--- a/application/src/main/scala/cloud/benchflow/experiment/sources/processors/drivers/operations/http/HttpDriverOperationsProcessor.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/sources/processors/drivers/operations/http/HttpDriverOperationsProcessor.scala
@@ -1,10 +1,16 @@
 package cloud.benchflow.experiment.sources.processors.drivers.operations.http
 
+import cloud.benchflow.experiment.GenerationDefaults
 import cloud.benchflow.experiment.sources.processors._
 import cloud.benchflow.driversmaker.utils.env.DriversMakerEnv
 import cloud.benchflow.test.config.experiment.BenchFlowExperiment
-import cloud.benchflow.test.config.sut.http.HttpDriver
-import spoon.reflect.declaration.CtClass
+import cloud.benchflow.test.config.sut.http._
+import com.sun.faban.driver.{Timing, BenchmarkOperation}
+import spoon.reflect.code.{CtStatement, CtFieldAccess}
+import spoon.reflect.declaration.{ModifierKind, CtMethod, CtClass}
+import spoon.reflect.reference.{CtFieldReference, CtTypeReference}
+
+import scala.collection.mutable
 
 /**
   * @author Simone D'Avico (simonedavico@gmail.com)
@@ -12,14 +18,155 @@ import spoon.reflect.declaration.CtClass
   * An implementation of [[DriverOperationsProcessor]] that generates
   * operations and related annotations for an http driver
   */
-class HttpDriverOperationsProcessor(expConfig: BenchFlowExperiment,
+class HttpDriverOperationsProcessor[T <: HttpOperation](expConfig: BenchFlowExperiment,
                                     driver: HttpDriver,
                                     experimentId: String)(implicit env: DriversMakerEnv)
   extends DriverOperationsProcessor(expConfig, driver, experimentId)(env) {
 
-  override def doProcess(e: CtClass[_]): Unit = {
-    e.setSimpleName(driver.getClass.getSimpleName)
+  import HttpDriverOperationsProcessor._
 
-    //TODO: generate operations
+  private def hardcodeHeaders(op: HttpOperation): List[CtStatement] = {
+
+    val stmts = mutable.ListBuffer.empty[CtStatement]
+
+    //first, declare the headers map
+    stmts += getFactory.Code().createCodeSnippetStatement(
+      s"Map<String, String> $headersMapName = new HashMap<String, String>()"
+    )
+
+    //then, add all headers
+    op.headers.foreach { header =>
+
+      stmts += getFactory.Code().createCodeSnippetStatement(
+        s"""headers.put("${header._1}", "${header._2}")"""
+      )
+
+    }
+
+    stmts.toList
   }
+
+
+  private def generateGetOperation(method: CtMethod[Void], op: HttpOperation): Unit = {
+
+    val headersStmts = hardcodeHeaders(op)
+
+    headersStmts.foreach { headerStmt =>
+      method.getBody.addStatement(headerStmt)
+      ()
+    }
+
+    method.getBody.insertEnd(
+      getFactory.Code().createCodeSnippetStatement(
+        s"""http.fetchUrl("${op.endpoint}", $headersMapName)"""
+      )
+    )
+
+  }
+
+
+  private def generateDeleteOperation(method: CtMethod[Void], op: HttpOperation): Unit = {
+
+    val headersStmts = hardcodeHeaders(op)
+
+    headersStmts.foreach { headerStmt =>
+      method.getBody.addStatement(headerStmt)
+      ()
+    }
+
+    method.getBody.insertEnd(
+      getFactory.Code.createCodeSnippetStatement(
+        s"""http.deleteUrl("${op.endpoint}")"""
+      )
+    )
+
+  }
+
+
+  private def generatePutOperation(method: CtMethod[Void], op: HttpOperation): Unit = {
+
+    val headersStmts = hardcodeHeaders(op)
+
+    headersStmts.foreach { headerStmt =>
+      method.getBody.addStatement(headerStmt)
+      ()
+    }
+
+    val contentType = op.headers.get("Content-Type") match {
+      case Some(cType) => cType
+      case None => "text/plain"
+    }
+
+    method.getBody.insertEnd(
+      getFactory.Code.createCodeSnippetStatement(
+        s"""http.putUrl("${op.endpoint}",
+           |"${op.data}".getBytes(java.nio.charset.Charset.forName("UTF-8")),
+           |"$contentType", $headersMapName)""".stripMargin
+      )
+    )
+
+
+  }
+
+  private def generatePostOperation(method: CtMethod[Void], op: HttpOperation): Unit = {
+
+    val headerStmts = hardcodeHeaders(op)
+
+    headerStmts.foreach { headerStmt =>
+      method.getBody.addStatement(headerStmt)
+      ()
+    }
+
+    method.getBody.insertEnd(
+      getFactory.Code.createCodeSnippetStatement(
+        op.data match {
+          case Some(payload) => s"""http.fetchUrl("${op.endpoint}", "$payload", $headersMapName)"""
+          case None =>   s"""http.fetchUrl("${op.endpoint}", $headersMapName)"""
+        }
+      )
+    )
+  }
+
+  override protected def generateOperation(element: CtClass[_])(op: HttpOperation): Unit = {
+
+    val methodName = s"do${op.name.capitalize}Request"
+    val methodBody = getFactory.Core().createBlock()
+    val method: CtMethod[Void] = getFactory.Method()
+      .create(element,
+        getFactory.Code().modifiers(ModifierKind.PUBLIC),
+        getFactory.Type().VOID_PRIMITIVE,
+        methodName,
+        null, null, methodBody)
+
+    method.addThrownType(getFactory.Type().createReference(classOf[java.lang.Exception]))
+
+
+    op.method match {
+      case Get    => generateGetOperation(method, op)
+      case Post   => generatePostOperation(method, op)
+      case Put    => generatePutOperation(method, op)
+      case Delete => generateDeleteOperation(method, op)
+    }
+
+    //add @BenchmarkOperation annotation
+    val benchmarkOperationAnnotation = getFactory.Annotation().annotate(method, classOf[BenchmarkOperation])
+    val benchmarkOperationName = getFactory.Code().createLiteral(op.name)
+    benchmarkOperationAnnotation.addValue("name", benchmarkOperationName)
+    benchmarkOperationAnnotation.addValue("max90th", driver.configuration.flatMap(_.max90th).getOrElse(GenerationDefaults.max90th))
+    val fieldRead: CtFieldAccess[Timing] = getFactory.Core().createFieldRead()
+    val enumReference: CtTypeReference[Timing] = getFactory.Type().createReference(classOf[Timing])
+    val fieldReference: CtFieldReference[Timing] = getFactory.Field()
+      .createReference(enumReference, enumReference, Timing.AUTO.name())
+    fieldReference.setStatic(true)
+    fieldRead.setVariable(fieldReference)
+    benchmarkOperationAnnotation.addValue("timing", fieldRead)
+
+
+  }
+
+}
+object HttpDriverOperationsProcessor {
+
+  val headersMapName = "headers"
+
 }

--- a/application/src/main/scala/cloud/benchflow/experiment/sources/processors/drivers/operations/wfms/WfMSDriverOperationsProcessor.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/sources/processors/drivers/operations/wfms/WfMSDriverOperationsProcessor.scala
@@ -1,0 +1,17 @@
+package cloud.benchflow.experiment.sources.processors.drivers.operations.wfms
+
+import cloud.benchflow.driversmaker.utils.env.DriversMakerEnv
+import cloud.benchflow.experiment.sources.processors.DriverOperationsProcessor
+import cloud.benchflow.test.config.experiment.BenchFlowExperiment
+import cloud.benchflow.test.config.sut.wfms.{WfMSDriver, WfMSOperation}
+
+/**
+  * @author Simone D'Avico (simonedavico@gmail.com)
+  *
+  * Created on 28/07/16.
+  */
+/** base class for a processor that generates operations for a wfms driver */
+abstract class WfMSDriverOperationsProcessor[T <: WfMSOperation](benchFlowBenchmark: BenchFlowExperiment,
+                                                                 driver: WfMSDriver,
+                                                                 experimentId: String)(implicit env: DriversMakerEnv)
+  extends DriverOperationsProcessor(benchFlowBenchmark, driver, experimentId)(env)

--- a/application/src/main/scala/cloud/benchflow/experiment/sources/processors/package.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/sources/processors/package.scala
@@ -1,7 +1,7 @@
 package cloud.benchflow.experiment.sources
 
 import cloud.benchflow.driversmaker.utils.env.DriversMakerEnv
-import cloud.benchflow.test.config.sut.wfms.WfMSDriver
+import cloud.benchflow.test.config.sut.wfms.{WfMSOperation, WfMSDriver}
 import cloud.benchflow.test.config.{Operation, Driver}
 import cloud.benchflow.test.config.experiment.BenchFlowExperiment
 import spoon.processing.AbstractProcessor
@@ -62,15 +62,18 @@ package object processors {
     extends BenchmarkSourcesProcessor(benchFlowBenchmark, experimentId)(env)
 
   /** base class for a processor that generates operations for a driver */
-  abstract class DriverOperationsProcessor(benchflowBenchmark: BenchFlowExperiment,
-                                           driver: Driver[_ <: Operation],
+  abstract class DriverOperationsProcessor[T <: Operation](benchflowBenchmark: BenchFlowExperiment,
+                                           driver: Driver[T],
                                            experimentId: String)(implicit env: DriversMakerEnv)
-    extends DriverProcessor(benchflowBenchmark, driver, experimentId)(env)
+    extends DriverProcessor(benchflowBenchmark, driver, experimentId)(env) {
 
-  /** base class for a processor that generates operations for a wfms driver */
-  abstract class WfMSDriverOperationsProcessor(benchFlowBenchmark: BenchFlowExperiment,
-                                               driver: WfMSDriver,
-                                               experimentId: String)(implicit env: DriversMakerEnv)
-    extends DriverOperationsProcessor(benchFlowBenchmark, driver, experimentId)(env)
+    protected def generateOperation(element: CtClass[_])(op: T): Unit
+
+    override def doProcess(element: CtClass[_]) = {
+      element.setSimpleName(driver.getClass.getSimpleName)
+      driver.operations.foreach(generateOperation(element))
+    }
+
+  }
 
 }

--- a/application/src/test/resources/app/drivers/templates/driver/http/Driver.java
+++ b/application/src/test/resources/app/drivers/templates/driver/http/Driver.java
@@ -1,7 +1,12 @@
 package cloud.benchflow.experiment.drivers;
 
 import cloud.benchflow.driversmaker.generation.BenchFlowDriver;
+import java.util.*;
 
 public class Driver extends BenchFlowDriver {
+
+    public Driver() throws Exception {
+        super();
+    }
 
 }

--- a/application/src/test/resources/app/drivers/templates/harness/http/HttpBenchmark.java
+++ b/application/src/test/resources/app/drivers/templates/harness/http/HttpBenchmark.java
@@ -8,6 +8,7 @@ public class HttpBenchmark extends BenchFlowBenchmark {
 
     private static Logger logger = Logger.getLogger(HttpBenchmark.class.getName());
 
+    @Override
     protected void initialize() throws Exception {
         super.initialize();
     }

--- a/application/src/test/resources/benchflow-test.yml
+++ b/application/src/test/resources/benchflow-test.yml
@@ -1,7 +1,8 @@
 sut:
     name: camunda
     version: 3.5.0
-    type: WfMS
+    type: http
+#    type: WfMS
 
 testName: WfMSTest
 description: A WfMS test
@@ -20,16 +21,26 @@ properties:
 
 
 drivers:
-- start:
+- http:
     properties:
-        stats:
-            interval: 30
+      stats:
+        interval: 30
     operations:
-    - myModel.bpmn
-    configuration:
-        mix:
-            fixedSequence: [ myModel ]
-            deviation: 5
+    - getProfile:
+        endpoint: /get-profile
+        method: GET
+        headers:
+          Content-Type: foobar
+#- start:
+#    properties:
+#        stats:
+#            interval: 30
+#    operations:
+#    - myModel.bpmn
+#    configuration:
+#        mix:
+#            fixedSequence: [ myModel ]
+#            deviation: 5
 
 
 sutConfiguration:

--- a/application/src/test/scala/cloud/benchflow/experiment/sources/GenerationTest.scala
+++ b/application/src/test/scala/cloud/benchflow/experiment/sources/GenerationTest.scala
@@ -40,7 +40,7 @@ object GenerationTest extends App {
     env = benchFlowEnv
   )
   val resolvedDC = dcBuilder.resolveDeploymentDescriptor(parsedDc, trial)
-  println(DockerCompose.toYaml(resolvedDC))
+  //println(DockerCompose.toYaml(resolvedDC))
 
   val runXmlBuilder = new FabanBenchmarkConfigurationBuilder(parsedExpConfig,benchFlowEnv,parsedDc)
   //println(new PrettyPrinter(400, 2).format(runXmlBuilder.build(trial)))


### PR DESCRIPTION
- Completes code generation for http operations: now all http operations configurable in BenchFlow tests are correctly converted to Java code that executes them leveraging the Faban transport;
- Fixes one test/experiment/trial renaming leftover.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/drivers-maker/pull/56?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/drivers-maker/pull/56'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>