### PR TITLE
Adds sutEndpoint in http operations generation

### DIFF
--- a/application/src/main/scala/cloud/benchflow/experiment/sources/processors/drivers/operations/http/HttpDriverOperationsProcessor.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/sources/processors/drivers/operations/http/HttpDriverOperationsProcessor.scala
@@ -58,7 +58,7 @@ class HttpDriverOperationsProcessor[T <: HttpOperation](expConfig: BenchFlowExpe
 
     method.getBody.insertEnd(
       getFactory.Code().createCodeSnippetStatement(
-        s"""http.fetchUrl("${op.endpoint}", $headersMapName)"""
+        s"""http.fetchUrl(sutEndpoint + "${op.endpoint}", $headersMapName)"""
       )
     )
 
@@ -76,7 +76,7 @@ class HttpDriverOperationsProcessor[T <: HttpOperation](expConfig: BenchFlowExpe
 
     method.getBody.insertEnd(
       getFactory.Code.createCodeSnippetStatement(
-        s"""http.deleteUrl("${op.endpoint}")"""
+        s"""http.deleteUrl(sutEndpoint + "${op.endpoint}")"""
       )
     )
 
@@ -99,7 +99,7 @@ class HttpDriverOperationsProcessor[T <: HttpOperation](expConfig: BenchFlowExpe
 
     method.getBody.insertEnd(
       getFactory.Code.createCodeSnippetStatement(
-        s"""http.putUrl("${op.endpoint}",
+        s"""http.putUrl(sutEndpoint + "${op.endpoint}",
            |"${op.data}".getBytes(java.nio.charset.Charset.forName("UTF-8")),
            |"$contentType", $headersMapName)""".stripMargin
       )
@@ -120,8 +120,8 @@ class HttpDriverOperationsProcessor[T <: HttpOperation](expConfig: BenchFlowExpe
     method.getBody.insertEnd(
       getFactory.Code.createCodeSnippetStatement(
         op.data match {
-          case Some(payload) => s"""http.fetchUrl("${op.endpoint}", "$payload", $headersMapName)"""
-          case None =>   s"""http.fetchUrl("${op.endpoint}", $headersMapName)"""
+          case Some(payload) => s"""http.fetchUrl(sutEndpoint + "${op.endpoint}", "$payload", $headersMapName)"""
+          case None =>   s"""http.fetchUrl(sutEndpoint + "${op.endpoint}", $headersMapName)"""
         }
       )
     )

--- a/application/src/test/resources/docker-compose.yml
+++ b/application/src/test/resources/docker-compose.yml
@@ -1,4 +1,4 @@
-version: 2
+version: '2'
 services:
   camunda:
     image: camunda/camunda-bpm-platform:tomcat-7.4.0


### PR DESCRIPTION
Also fixes docker-compose version (should be a string, not a number) in
docker-compose test file.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/drivers-maker/pull/58?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/drivers-maker/pull/58'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>