### PR TITLE
Adds normalisation for operations' endpoints

### DIFF
--- a/application/src/test/scala/cloud/benchflow/experiment/TestLibrariesWorksheet.sc
+++ b/application/src/test/scala/cloud/benchflow/experiment/TestLibrariesWorksheet.sc
@@ -1,3 +1,5 @@
+import java.net.{URI, URL}
+
 import io.minio.MinioClient
 
 //import java.io.{ByteArrayInputStream, StringWriter}
@@ -74,6 +76,6 @@ import io.minio.MinioClient
 //val foo: Node = docBuilder.parse(new ByteArrayInputStream(stringified.getBytes("utf-8"))).getDocumentElement
 //foo.getTextContent
 
-val mc = new MinioClient("http://localhost:19000", "AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
-val is = mc.getObject("benchmarks", "BenchFlow/WfMSTest/1/benchflow-test.yml")
-
+//val mc = new MinioClient("http://localhost:19000", "AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+//val is = mc.getObject("benchmarks", "BenchFlow/WfMSTest/1/benchflow-test.yml")
+val url = new URI("http://localhost:8080//").normalize().toString


### PR DESCRIPTION
Adds normalisation for operations’ endpoints to address cases where an
URL with a double slash can be generated (e.g., http://ip:port//).

This can happen if targetService endpoint is /, and operation endpoint
is / as well.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/drivers-maker/pull/60?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/drivers-maker/pull/60'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>