### PR TITLE
Safely removes empty variables from config.yml

### DIFF
--- a/application/src/main/java/cloud/benchflow/driversmaker/modules/BenchFlowEnvModule.java
+++ b/application/src/main/java/cloud/benchflow/driversmaker/modules/BenchFlowEnvModule.java
@@ -21,14 +21,18 @@ public class BenchFlowEnvModule extends AbstractModule {
 
     }
 
-    @Provides @Singleton
+    @Provides
+    @Singleton
     @Named("generationEnv")
     public DriversMakerEnv providesBenchFlowEnv(DriversMakerConfiguration dmc) throws FileNotFoundException {
+
         String configYmlPath = dmc.getBenchFlowEnvConfiguration().getConfigPath();
         String bfServicesPath = dmc.getBenchFlowEnvConfiguration().getBenchFlowServicesPath();
         String generationResourcesPath = dmc.getBenchFlowEnvConfiguration().getGenerationResourcesPath();
         String privatePort = dmc.getBenchFlowEnvConfiguration().getPrivatePort();
+
         ConfigYml benv = new ConfigYml(configYmlPath);
+
         return new DriversMakerEnv(benv, bfServicesPath, generationResourcesPath, privatePort);
     }
 

--- a/application/src/main/java/cloud/benchflow/driversmaker/utils/env/ConfigYml.java
+++ b/application/src/main/java/cloud/benchflow/driversmaker/utils/env/ConfigYml.java
@@ -4,6 +4,7 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -36,14 +37,21 @@ public class ConfigYml {
         return (T) env.get(variable);
     }
 
-    public void reload() throws FileNotFoundException {
+    public void  reload() throws FileNotFoundException {
         Map<String, Object> parsedConfigYml = loadFromFile();
 
         //remote key that map to "" values
-        parsedConfigYml.keySet().stream().filter(
-                key -> parsedConfigYml.get(key).equals("")
-        )
-        .forEach(parsedConfigYml::remove);
+        Iterator<Map.Entry<String, Object>> parsedConfigIterator =
+                parsedConfigYml.entrySet().iterator();
+
+        while (parsedConfigIterator.hasNext()) {
+
+            Map.Entry<String, Object> variable = parsedConfigIterator.next();
+            if(variable.getValue().equals("")) {
+                parsedConfigIterator.remove();
+            }
+
+        }
 
         this.env = parsedConfigYml;
     }


### PR DESCRIPTION
Fixes a bug that was causing a ConcurrentModificationException if
removing a key from the parsed config.yml while iterating over the keys.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/drivers-maker/pull/65?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/drivers-maker/pull/65'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>