### PR TITLE
Fixes incorrect generation of main driver class complete name

### DIFF
--- a/application/src/main/java/cloud/benchflow/driversmaker/generation/BenchFlowBenchmark.java
+++ b/application/src/main/java/cloud/benchflow/driversmaker/generation/BenchFlowBenchmark.java
@@ -168,7 +168,7 @@ public class BenchFlowBenchmark extends DefaultFabanBenchmark2 {
     protected void moveBenchFlowServicesConfigToProperties() throws Exception {
 
         Document runDoc = params.getTopLevelElements().item(0).getOwnerDocument();
-        String driverConfigNodeXPath = "fa:runConfig/fd:driverConfig[1]";
+        String driverConfigNodeXPath = "fa:runConfig/driverConfig[1]";
         Element driverConfigNode = (Element) runXml.getNode(driverConfigNodeXPath);
         Element driverProperties = (Element) runXml.getNode("properties", driverConfigNode);
         Element benchFlowServicesConfiguration = (Element) runXml.getNode("benchFlowServices");

--- a/application/src/main/scala/cloud/benchflow/experiment/config/FabanBenchmarkConfigurationBuilder.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/config/FabanBenchmarkConfigurationBuilder.scala
@@ -213,7 +213,7 @@ class FabanBenchmarkConfigurationBuilder(expConfig: BenchFlowExperiment,
           <fh:jvmOptions>{ getJavaOpts }</fh:jvmOptions>
         </jvmConfig>
 
-        <fa:runConfig definition={s"cloud.benchflow.benchmark.drivers.${expConfig.drivers.head.getClass.getSimpleName}"}
+        <fa:runConfig definition={s"cloud.benchflow.experiment.drivers.${expConfig.drivers.head.getClass.getSimpleName}"}
                       xmlns:fa="http://faban.sunsource.net/ns/faban"
                       xmlns:fh="http://faban.sunsource.net/ns/fabanharness"
                       xmlns="http://faban.sunsource.net/ns/fabandriver">


### PR DESCRIPTION
- Fixes incorrect generation of main driver class complete name in
Faban config file;
- Fixes retrieval of driverConfig node in BenchFlowBenchmark to account
for the removal of fd namespace
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/drivers-maker/pull/67?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/drivers-maker/pull/67'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>