### PR TITLE
Fixes generated Faban benchmark configuration file

### DIFF
--- a/application/src/main/scala/cloud/benchflow/experiment/config/FabanBenchmarkConfigurationBuilder.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/config/FabanBenchmarkConfigurationBuilder.scala
@@ -217,52 +217,54 @@ class FabanBenchmarkConfigurationBuilder(expConfig: BenchFlowExperiment,
                       xmlns:fa="http://faban.sunsource.net/ns/faban"
                       xmlns:fh="http://faban.sunsource.net/ns/fabanharness"
                       xmlns="http://faban.sunsource.net/ns/fabandriver">
-          <fh:description>{ expConfig.description }</fh:description>
-          <fa:scale>{ scaleBalancer.scale }</fa:scale>
-          <fh:timeSync>{ GenerationDefaults.timeSync }</fh:timeSync>
-          <fa:hostConfig>
-            <fa:host>{ usedHosts.map { case (host, numOfAgents) => s"$host" }.mkString(" ") }</fa:host>
-            <fh:tools>NONE</fh:tools>
-          </fa:hostConfig>
+            <fh:description>{ expConfig.description }</fh:description>
 
-          {
-            val xmlProps = convert(expConfig.properties).map(addFabanNamespace)
-            xmlProps.map(insertIntervalIfNotExists)
-            //++ bb.drivers.map(convertDriver).map(addFabanNamespace) }
-          }
+            <fa:scale>{ scaleBalancer.scale }</fa:scale>
+            <fh:timeSync>{ GenerationDefaults.timeSync }</fh:timeSync>
 
-          { agents.map { case (d, hosts) => convertDriver(d, hosts) } }
+            <fa:hostConfig>
+              <fa:host>{ usedHosts.map { case (host, numOfAgents) => s"$host" }.mkString(" ") }</fa:host>
+              <fh:tools>NONE</fh:tools>
+            </fa:hostConfig>
 
-          <fa:runControl unit="time">
-            <fa:rampUp>{ expConfig.execution.rampUp }</fa:rampUp>
-            <fa:steadyState>{ expConfig.execution.steadyState }</fa:steadyState>
-            <fa:rampDown>{ expConfig.execution.rampDown }</fa:rampDown>
-          </fa:runControl>
+            {
+              val xmlProps = convert(expConfig.properties).map(addFabanNamespace)
+              xmlProps.map(insertIntervalIfNotExists)
+              //++ bb.drivers.map(convertDriver).map(addFabanNamespace) }
+            }
 
-          <threadStart>
-            <delay>{ benv.getHeuristics.threadStart.delay(expConfig, usedHosts.size) }</delay>
-            <simultaneous>{ benv.getHeuristics.threadStart.simultaneous(expConfig) }</simultaneous>
-            <parallel>{ benv.getHeuristics.threadStart.parallel(expConfig) }</parallel>
-          </threadStart>
+            { agents.map { case (d, hosts) => convertDriver(d, hosts) } }
 
-          <sutConfiguration>
-            <serviceName>{ expConfig.sutConfiguration.targetService.name }</serviceName>
-            <endpoint>{ expConfig.sutConfiguration.targetService.endpoint }</endpoint>
-          </sutConfiguration>
+            <fa:runControl unit="time">
+              <fa:rampUp>{ expConfig.execution.rampUp }</fa:rampUp>
+              <fa:steadyState>{ expConfig.execution.steadyState }</fa:steadyState>
+              <fa:rampDown>{ expConfig.execution.rampDown }</fa:rampDown>
+            </fa:runControl>
 
-          <benchFlowServices>
-              <privatePort>{ benv.getPrivatePort }</privatePort>
-              <deploymentManager>{ benv.getDeploymentManagerAddress }</deploymentManager>
-              <servicesConfiguration>
-                { deploymentDescriptor.services.keys.map(serviceConfiguration)  }
-              </servicesConfiguration>
-           </benchFlowServices>
-
-           <benchFlowRunConfiguration>
-             <trialId>{trial.getTrialId}</trialId>
-           </benchFlowRunConfiguration>
+            <threadStart>
+              <delay>{ benv.getHeuristics.threadStart.delay(expConfig, usedHosts.size) }</delay>
+              <simultaneous>{ benv.getHeuristics.threadStart.simultaneous(expConfig) }</simultaneous>
+              <parallel>{ benv.getHeuristics.threadStart.parallel(expConfig) }</parallel>
+            </threadStart>
 
         </fa:runConfig>
+
+        <sutConfiguration>
+          <serviceName>{ expConfig.sutConfiguration.targetService.name }</serviceName>
+          <endpoint>{ expConfig.sutConfiguration.targetService.endpoint }</endpoint>
+        </sutConfiguration>
+
+        <benchFlowServices>
+            <privatePort>{ benv.getPrivatePort }</privatePort>
+            <deploymentManager>{ benv.getDeploymentManagerAddress }</deploymentManager>
+            <servicesConfiguration>
+              { deploymentDescriptor.services.keys.map(serviceConfiguration)  }
+            </servicesConfiguration>
+         </benchFlowServices>
+
+         <benchFlowRunConfiguration>
+           <trialId>{trial.getTrialId}</trialId>
+         </benchFlowRunConfiguration>
 
       </xml>.copy(label = expConfig.name)
     )

--- a/application/src/main/scala/cloud/benchflow/experiment/heuristics/jvm/LogisticGrowth.scala
+++ b/application/src/main/scala/cloud/benchflow/experiment/heuristics/jvm/LogisticGrowth.scala
@@ -25,7 +25,7 @@ class LogisticsGrowthJvmParamsHeuristic(mapConfig: Map[String, Any])(env: Config
 
   //see https://en.wikipedia.org/wiki/Logistic_function
   override def xmx(expConfig: BenchFlowExperiment): Int = {
-    val L = config.maxMemory
+    val L = config.maxMemory + config.xms
     val x = expConfig.users.users
     val x0 = config.maxUsers/2
     (L/(1 + Math.exp(-config.k * (x - x0))) + config.xms).toInt

--- a/application/src/test/scala/cloud/benchflow/experiment/sources/GenerationTest.scala
+++ b/application/src/test/scala/cloud/benchflow/experiment/sources/GenerationTest.scala
@@ -10,6 +10,8 @@ import cloud.benchflow.driversmaker.utils.env.{DriversMakerEnv, ConfigYml}
 import cloud.benchflow.test.config.experiment.BenchFlowExperiment
 import cloud.benchflow.test.deployment.docker.compose.DockerCompose
 
+import scala.xml.PrettyPrinter
+
 /**
   * @author Simone D'Avico (simonedavico@gmail.com)
   *
@@ -40,10 +42,10 @@ object GenerationTest extends App {
     env = benchFlowEnv
   )
   val resolvedDC = dcBuilder.resolveDeploymentDescriptor(parsedDc, trial)
-  println(DockerCompose.toYaml(resolvedDC))
+//  println(DockerCompose.toYaml(resolvedDC))
 
   val runXmlBuilder = new FabanBenchmarkConfigurationBuilder(parsedExpConfig,benchFlowEnv,parsedDc)
-//  println(new PrettyPrinter(400, 2).format(runXmlBuilder.build(trial)))
+  println(new PrettyPrinter(400, 2).format(runXmlBuilder.build(trial)))
 
   val siblingResolver = new SiblingVariableResolver(parsedDc, benchFlowEnv, parsedExpConfig)
 
@@ -54,6 +56,6 @@ object GenerationTest extends App {
     env = benchFlowEnv
   )
 
-  benchmarkSourcesGenerator.generate()
+//  benchmarkSourcesGenerator.generate()
 
 }


### PR DESCRIPTION
- the runConfig node in the generated Faban configuration file was
including also the nodes sutConfiguration, benchFlowServices, and
benchFlowRunConfiguration, which contain BenchFlow related info.
This is probably the cause of a bug which is preventing generated
benchmarks to run on the harness.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/drivers-maker/pull/68?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/drivers-maker/pull/68'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>